### PR TITLE
Pc prompt constructor

### DIFF
--- a/scripts/generator.js
+++ b/scripts/generator.js
@@ -1,5 +1,5 @@
 //Construct a prompt based on the given parameters.
-export function constructPrompt(language, system, world, subject, subjectType, key) {
+export function constructPrompt(language, system, world, subject, subjectType='', descriptionType='', key=game.settings.get('ai-description-generator', 'key')) {
 	//A mapping for Foundry's languages since only the key is stored but the value is needed.
 	const foundryLanguages = {
 		"en": "English",
@@ -31,7 +31,7 @@ export function constructPrompt(language, system, world, subject, subjectType, k
 		'aus'
 	];
 
-	const defaultPrompt = 'Reply in {language}. This is a tabletop roleplaying game using the {system} system and the {world} setting. Give a cool short sensory description the game master can use for a {subject} {subjectType}.';
+	const defaultPrompt = 'Reply in {language}. This is a tabletop roleplaying game using the {system} system and the {world} setting. Give a {descriptionType} description the game master can use for a {subject} {subjectType}.';
 	var prompt = game.settings.get('ai-description-generator', 'prompt');
 	if (prompt === defaultPrompt) {
 		//If the module's language setting is left blank use the core language setting instead.
@@ -44,13 +44,16 @@ export function constructPrompt(language, system, world, subject, subjectType, k
 		if (world == '') prompt = prompt.replace(' and the {world} setting', '');
 		//If no subject type is given remove it from the prompt.
 		if (subjectType == '') prompt = prompt.replace(' {subjectType}', '');
+		//If no description type is given remove it from the prompt.
+		if (descriptionType == '') prompt = prompt.replace(' {descriptionType}', '');
 	}
 	var prompt_mapping = {
 		'{language}': language,
 		'{system}': system,
 		'{world}': world,
 		'{subject}': subject,
-		'{subjectType}': subjectType
+		'{subjectType}': subjectType,
+		'{descriptionType}': descriptionType
 	};
 	for (const [key, value] of Object.entries(prompt_mapping)) {
 		prompt = prompt.replace(key, value);

--- a/scripts/migration/1.6.0.js
+++ b/scripts/migration/1.6.0.js
@@ -1,0 +1,6 @@
+export function migrate_160() {
+	const oldPrompt = 'Reply in {language}. This is a tabletop roleplaying game using the {system} system and the {world} setting. Give a cool short sensory description the game master can use for a {subject} {subjectType}.';
+	const newPrompt = 'Reply in {language}. This is a tabletop roleplaying game using the {system} system and the {world} setting. Give a {descriptionType} description the game master can use for a {subject} {subjectType}.';
+	if (game.settings.get('ai-description-generator', 'prompt') === oldPrompt)
+		game.settings.set('ai-description-generator', 'prompt', newPrompt);
+}

--- a/scripts/migration/migration_handler.js
+++ b/scripts/migration/migration_handler.js
@@ -1,0 +1,19 @@
+import { migrate_160 } from "./1.6.0.js";
+
+export function migrationHandler() {
+	const moduleVersion = parseInt(game.modules.get('ai-description-generator').version.split('.').join(''));
+	const migrationVersion = game.settings.get('ai-description-generator', 'migration_version');
+	if (migrationVersion < moduleVersion) {
+		console.warn(`AI Description Generator | Migrating World to ${game.modules.get('ai-description-generator').version}!`);
+		switch (migrationVersion) {
+			case 150:
+				migrate_160();
+			//case 160:
+				//migrate_170();
+			//case 170:
+				//migrate_180();
+			//...
+		};
+	}
+	game.settings.set('ai-description-generator', 'migration_version', moduleVersion)
+}

--- a/scripts/settings.js
+++ b/scripts/settings.js
@@ -59,7 +59,7 @@ export function registerSettings() {
 		scope: 'world',
 		config: true,
 		type: String,
-		default: 'Reply in {language}. This is a tabletop roleplaying game using the {system} system and the {world} setting. Give a cool short sensory description the game master can use for a {subject} {subjectType}.'
+		default: 'Reply in {language}. This is a tabletop roleplaying game using the {system} system and the {world} setting. Give a {descriptionType} description the game master can use for a {subject} {subjectType}.'
 	});
 
 	game.settings.register('ai-description-generator', 'max_tokens', {
@@ -128,5 +128,14 @@ export function registerSettings() {
 		config: true,
 		type: Boolean,
 		default: false
+	});
+
+	game.settings.register('ai-description-generator', 'migration_version', {
+		name: 'Migration Version',
+		hint: 'Internal versioning to help with data migration during updates',
+		scope: 'world',
+		config: true,
+		type: Number,
+		default: 150
 	});
 }

--- a/scripts/settings.js
+++ b/scripts/settings.js
@@ -134,7 +134,7 @@ export function registerSettings() {
 		name: 'Migration Version',
 		hint: 'Internal versioning to help with data migration during updates',
 		scope: 'world',
-		config: true,
+		config: false,
 		type: Number,
 		default: 150
 	});


### PR DESCRIPTION
- Player character sheets now have a GPT-3 button to generate a special prompt that takes into account the character's lineage, class(es), and anything they write in the Appearance textbox.
- Added an (optional) `descriptionType` argument to the `constructPrompt` function. This was needed to create better prompts for player characters. This sadly breaks existing macros using this function.
- Made the `subjectType` and `key` arguments optional, defaulting to an empty string and the key specified in the module settings respectively.
- Added functions to take care of data migration.
- The prompt setting when left on default will be migrated to include the new `descriptionType` argument.