### PR TITLE
Add basic combat narrator for pf1

### DIFF
--- a/scripts/api.js
+++ b/scripts/api.js
@@ -1,9 +1,10 @@
-import { constructPrompt, sendPrompt } from "./generator.js";
+import { constructDescriptionPrompt, constructCombatPrompt, sendPrompt } from "./generator.js";
 
 export function registerAPI() {
 	if (!game.settings.get('ai-description-generator', 'api') || game.user.role < game.settings.get('ai-description-generator', 'api_permission')) return;
 	game.modules.get('ai-description-generator').api = {
-		constructPrompt,
+		constructDescriptionPrompt,
+		constructCombatPrompt,
 		sendPrompt
 	};
 }

--- a/scripts/chat_commands.js
+++ b/scripts/chat_commands.js
@@ -1,4 +1,4 @@
-import { constructPrompt, sendPrompt } from "./generator.js";
+import { constructDescriptionPrompt, sendPrompt } from "./generator.js";
 
 
 export function addChatCommands(log, data, chatData) {
@@ -14,10 +14,7 @@ export function addChatCommands(log, data, chatData) {
 		const args = data.split(' ').slice(2, this.length);
 		if (args.length === 0) return;
 		var subject = args.join(' ');
-		constructPrompt(
-			game.settings.get('ai-description-generator', 'language'),
-			game.settings.get('ai-description-generator', 'system'),
-			game.settings.get('ai-description-generator', 'world'),
+		constructDescriptionPrompt(			
 			subject,
 			'',
 			'cool short sensory'

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1,7 +1,7 @@
 import { registerSettings } from './settings.js';
 import { registerAPI } from './api.js';
 import { migrationHandler } from './migration/migration_handler.js';
-import { constructPrompt } from './generator.js';
+import { constructCombatPrompt, constructDescriptionPrompt } from './generator.js';
 import { addChatCommands } from './chat_commands.js';
 
 //Register the settings and api function when Foundry is ready.
@@ -32,10 +32,7 @@ Hooks.on('getActorSheetHeaderButtons', (sheet, headerButtons) => {
 			icon: 'fas fa-comment-dots',
 			class: 'gpt-actor-button',
 			onclick: () => {
-				constructPrompt(
-					game.settings.get('ai-description-generator', 'language'),
-					game.settings.get('ai-description-generator', 'system'),
-					game.settings.get('ai-description-generator', 'world'),
+				constructDescriptionPrompt(					
 					subject,
 					subjectContext,
 					'cool short visual'
@@ -51,10 +48,7 @@ Hooks.on('getActorSheetHeaderButtons', (sheet, headerButtons) => {
 			icon: 'fas fa-comment-dots',
 			class: 'gpt-actor-button',
 			onclick: () => {
-				constructPrompt(
-					game.settings.get('ai-description-generator', 'language'),
-					game.settings.get('ai-description-generator', 'system'),
-					game.settings.get('ai-description-generator', 'world'),
+				constructDescriptionPrompt(					
 					actor.name,
 					subjectTypeMapping[actorType],
 					'cool short sensory'
@@ -109,3 +103,42 @@ Hooks.on('getItemSheetHeaderButtons', (sheet, headerButtons) => {
 });
 
 Hooks.on('chatMessage', addChatCommands);
+
+Hooks.on('renderChatMessage', async (log, data, chatData) => {	
+	if (game.user.role < game.settings.get('ai-description-generator', 'button_permission')) return;
+
+	var targetToken = canvas.tokens.get(log.flags.pf1.metadata.targets[0]);
+	if(!targetToken) return;
+
+	var describeButton = $('<a>', {
+		class: 'gpt-actor-button',
+		style: 'font-size: 15px; justify-content: right; display: flex; align-items: center; padding-right: 5px;'})			
+	describeButton.append($('<i>', {
+		class: 'fas fa-comment-dots',
+		style: 'font-size: 30px; padding: 3px;'
+	}));
+	describeButton.append('Describe');
+
+	switch(game.system.id){
+		case 'pf1': 
+		if(data.find('chat-attack')) {
+			var $header = data.find('.card-header');
+			if(!$header) return;
+			describeButton.click(() => {
+				let attacker = game.actors.get(log.speaker.actor);
+				let isAttackerNamed = !(attacker.type == 'npc' && attacker.name == log.speaker.alias);
+				
+				let targetActor = game.actors.get(targetToken.document.actorId);
+				let isTargetNamed = !(targetActor.type == 'npc' && targetActor.name == targetToken.name);
+
+				let attack = log.systemRolls.attacks[0].attack.options.flavor;
+				let isAttackHit = log.systemRolls.attacks[0].attack.total > targetActor.system.attributes.ac.normal.total;
+				let damage = log.systemRolls.attacks[0].damage[0].total;
+
+				constructCombatPrompt(attacker, isAttackerNamed, targetActor, isTargetNamed, attack, isAttackHit, damage);
+			});
+			$header.append(describeButton);		
+		}
+		break;
+	}
+});

--- a/scripts/settings.js
+++ b/scripts/settings.js
@@ -86,13 +86,31 @@ export function registerSettings() {
 		default: 'GPT-3'
 	});
 
-	game.settings.register('ai-description-generator', 'prompt', {
-		name: 'AI Prompt',
+	game.settings.register('ai-description-generator', 'basePrompt', {
+		name: 'Base Prompt',
 		hint: 'The prompt that is used to contruct a request for GPT-3. Only alter this if you are dissatified with the results and know what you are doing!',
 		scope: 'world',
 		config: true,
 		type: String,
-		default: 'Reply in {language}. This is a tabletop roleplaying game using the {system} system and the {world} setting. Give a {descriptionType} description the game master can use for a {subject} {subjectType}.'
+		default: 'Reply in {language}. This is a tabletop roleplaying game using {system}, set in {world}.'
+	});
+	
+	game.settings.register('ai-description-generator', 'descriptionPrompt', {
+		name: 'Description Prompt',
+		hint: 'This part of the prompt is used for providing static descriptions of items and characters.',
+		scope: 'world',
+		config: true,
+		type: String,
+		default: 'Give a {descriptionType} description the game master can use for a {subject} {subjectType}.'
+	});
+
+	game.settings.register('ai-description-generator', 'combatPrompt', {
+		name: 'Description Prompt',
+		hint: 'This part of the prompt is used for describing combat.',
+		scope: 'world',
+		config: true,
+		type: String,
+		default: 'Write a description for a round of combat with the following information. Attacker: {attacker}. Target: {target}. Weapon used:{weapon}. Attack effect: {effect}.'
 	});
 
 	game.settings.register('ai-description-generator', 'max_tokens', {


### PR DESCRIPTION
If you attack with another token set as a target, you can click a button on it in the chat log to get GPT-3 to generate a description of that combat round.

![Screenshot_2](https://user-images.githubusercontent.com/8267823/233484164-80c3db02-c607-4141-a81d-07aed5b732cf.png)

![Screenshot_3](https://user-images.githubusercontent.com/8267823/233484200-bb6c8ed0-c6ba-45ec-b1ea-567112aa7bd3.png)

Lacks some features which I intend to add soon.
